### PR TITLE
Add simple PDF parser

### DIFF
--- a/PdfToVideo/PdfContent.cs
+++ b/PdfToVideo/PdfContent.cs
@@ -1,0 +1,14 @@
+namespace PdfToVideo
+{
+    public class PdfContent
+    {
+        public string Text { get; set; }
+        public List<byte[]> Images { get; set; }
+
+        public PdfContent(string text, List<byte[]> images)
+        {
+            Text = text;
+            Images = images;
+        }
+    }
+}

--- a/PdfToVideo/PdfParser.cs
+++ b/PdfToVideo/PdfParser.cs
@@ -1,0 +1,50 @@
+using System.Text;
+using iText.Kernel.Pdf;
+using iText.Kernel.Pdf.Canvas.Parser;
+using iText.Kernel.Pdf.Canvas.Parser.Listener;
+using iText.Kernel.Pdf.Xobject;
+using iText.Kernel.Pdf.Colorspace;
+using iText.Kernel.Pdf.Filters;
+
+namespace PdfToVideo
+{
+    public static class PdfParser
+    {
+        public static PdfContent Extract(string pdfPath)
+        {
+            var textBuilder = new StringBuilder();
+            var images = new List<byte[]>();
+
+            using var reader = new PdfReader(pdfPath);
+            using var document = new PdfDocument(reader);
+
+            for (int i = 1; i <= document.GetNumberOfPages(); i++)
+            {
+                var page = document.GetPage(i);
+
+                // Extract text
+                var strategy = new SimpleTextExtractionStrategy();
+                textBuilder.AppendLine(PdfTextExtractor.GetTextFromPage(page, strategy));
+
+                // Extract images
+                var resources = page.GetResources();
+                var xObjects = resources.GetResource(PdfName.XObject);
+                if (xObjects != null)
+                {
+                    foreach (var name in xObjects.KeySet())
+                    {
+                        var obj = xObjects.GetAsStream(name);
+                        var subtype = obj.GetAsName(PdfName.Subtype);
+                        if (subtype != null && subtype.Equals(PdfName.Image))
+                        {
+                            var bytes = obj.GetBytes();
+                            images.Add(bytes);
+                        }
+                    }
+                }
+            }
+
+            return new PdfContent(textBuilder.ToString(), images);
+        }
+    }
+}

--- a/PdfToVideo/PdfToVideo.csproj
+++ b/PdfToVideo/PdfToVideo.csproj
@@ -7,4 +7,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="itext7" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/PdfToVideo/Program.cs
+++ b/PdfToVideo/Program.cs
@@ -1,10 +1,30 @@
-﻿namespace PdfToVideo
+using PdfToVideo;
+
+namespace PdfToVideo
 {
     internal class Program
     {
         static void Main(string[] args)
         {
-            Console.WriteLine("Hello, World!");
+            if (args.Length == 0)
+            {
+                Console.WriteLine("Usage: PdfToVideo <pdf-file-path>");
+                return;
+            }
+
+            string pdfPath = args[0];
+
+            try
+            {
+                PdfContent content = PdfParser.Extract(pdfPath);
+                Console.WriteLine("Text extracted from PDF:\n");
+                Console.WriteLine(content.Text);
+                Console.WriteLine($"Total images extracted: {content.Images.Count}");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to parse PDF: {ex.Message}");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add reference to itext7
- implement a `PdfParser` class to extract text and images
- add `PdfContent` model
- update Program to parse a pdf file from the command line

## Testing
- `dotnet build PdfToVideo.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a6dbd214832c9684d87e7a51dffe